### PR TITLE
Update to python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   test:
     docker:
-      - image: circleci/python:3.6.13
+      - image: circleci/python:3.9.4
         environment:
           NLTK_DATA: /root/nltk_data
     steps:

--- a/app/prestart.sh
+++ b/app/prestart.sh
@@ -1,4 +1,4 @@
-#  Note: Portions of this Dockerfile were taken from repositories licensed
+#  Note: The code in this file was copied from repositories licensed
 #  under the following license and copyright.
 #  Repositories:
 #     https://github.com/tiangolo/uvicorn-gunicorn-docker
@@ -27,36 +27,15 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
+#! /usr/bin/env sh
 
-FROM python:3.9.4
+echo "Running inside /app/prestart.sh, you could add migrations to this file, e.g.:"
 
-RUN pip install --no-cache-dir "uvicorn[standard]" gunicorn
+echo "
+#! /usr/bin/env bash
 
-COPY ./docker-support/start.sh /start.sh
-RUN chmod +x /start.sh
-
-COPY ./docker-support/gunicorn_conf.py /gunicorn_conf.py
-
-COPY ./docker-support/start-reload.sh /start-reload.sh
-RUN chmod +x /start-reload.sh
-
-COPY ./docker-support/app /app
-WORKDIR /app
-
-ENV PYTHONAPP=/app
-
-EXPOSE 80
-
-CMD ["/start.sh"]
-
-RUN pip install --no-cache-dir fastapi
-
-COPY requirements.txt /
-
-RUN pip install -r /requirements.txt
-
-ENV NLTK_DATA=/
-# Sorry container size
-RUN python -m textblob.download_corpora
-
-COPY ./app /app/app
+# Let the DB start
+sleep 10;
+# Run migrations
+alembic upgrade head
+"

--- a/docker-support/LICENSE
+++ b/docker-support/LICENSE
@@ -1,4 +1,4 @@
-#  Note: Portions of this Dockerfile were taken from repositories licensed
+#  Note: The code in this directory was copied from repositories licensed
 #  under the following license and copyright.
 #  Repositories:
 #     https://github.com/tiangolo/uvicorn-gunicorn-docker
@@ -26,37 +26,3 @@
 #  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
-
-
-FROM python:3.9.4
-
-RUN pip install --no-cache-dir "uvicorn[standard]" gunicorn
-
-COPY ./docker-support/start.sh /start.sh
-RUN chmod +x /start.sh
-
-COPY ./docker-support/gunicorn_conf.py /gunicorn_conf.py
-
-COPY ./docker-support/start-reload.sh /start-reload.sh
-RUN chmod +x /start-reload.sh
-
-COPY ./docker-support/app /app
-WORKDIR /app
-
-ENV PYTHONAPP=/app
-
-EXPOSE 80
-
-CMD ["/start.sh"]
-
-RUN pip install --no-cache-dir fastapi
-
-COPY requirements.txt /
-
-RUN pip install -r /requirements.txt
-
-ENV NLTK_DATA=/
-# Sorry container size
-RUN python -m textblob.download_corpora
-
-COPY ./app /app/app

--- a/docker-support/app/main.py
+++ b/docker-support/app/main.py
@@ -1,0 +1,13 @@
+import sys
+
+from fastapi import FastAPI
+
+version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root():
+    message = f"Hello world! From FastAPI running on Uvicorn with Gunicorn. Using Python {version}"
+    return {"message": message}

--- a/docker-support/app/prestart.sh
+++ b/docker-support/app/prestart.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env sh
+
+echo "Running inside /app/prestart.sh, you could add migrations to this file, e.g.:"
+
+echo "
+#! /usr/bin/env bash
+
+# Let the DB start
+sleep 10;
+# Run migrations
+alembic upgrade head
+"

--- a/docker-support/gunicorn_conf.py
+++ b/docker-support/gunicorn_conf.py
@@ -1,0 +1,67 @@
+import json
+import multiprocessing
+import os
+
+workers_per_core_str = os.getenv("WORKERS_PER_CORE", "1")
+max_workers_str = os.getenv("MAX_WORKERS")
+use_max_workers = None
+if max_workers_str:
+    use_max_workers = int(max_workers_str)
+web_concurrency_str = os.getenv("WEB_CONCURRENCY", None)
+
+host = os.getenv("HOST", "0.0.0.0")
+port = os.getenv("PORT", "80")
+bind_env = os.getenv("BIND", None)
+use_loglevel = os.getenv("LOG_LEVEL", "info")
+if bind_env:
+    use_bind = bind_env
+else:
+    use_bind = f"{host}:{port}"
+
+cores = multiprocessing.cpu_count()
+workers_per_core = float(workers_per_core_str)
+default_web_concurrency = workers_per_core * cores
+if web_concurrency_str:
+    web_concurrency = int(web_concurrency_str)
+    assert web_concurrency > 0
+else:
+    web_concurrency = max(int(default_web_concurrency), 2)
+    if use_max_workers:
+        web_concurrency = min(web_concurrency, use_max_workers)
+accesslog_var = os.getenv("ACCESS_LOG", "-")
+use_accesslog = accesslog_var or None
+errorlog_var = os.getenv("ERROR_LOG", "-")
+use_errorlog = errorlog_var or None
+graceful_timeout_str = os.getenv("GRACEFUL_TIMEOUT", "120")
+timeout_str = os.getenv("TIMEOUT", "120")
+keepalive_str = os.getenv("KEEP_ALIVE", "5")
+
+# Gunicorn config variables
+loglevel = use_loglevel
+workers = web_concurrency
+bind = use_bind
+errorlog = use_errorlog
+worker_tmp_dir = "/dev/shm"
+accesslog = use_accesslog
+graceful_timeout = int(graceful_timeout_str)
+timeout = int(timeout_str)
+keepalive = int(keepalive_str)
+
+
+# For debugging and testing
+log_data = {
+    "loglevel": loglevel,
+    "workers": workers,
+    "bind": bind,
+    "graceful_timeout": graceful_timeout,
+    "timeout": timeout,
+    "keepalive": keepalive,
+    "errorlog": errorlog,
+    "accesslog": accesslog,
+    # Additional, non-gunicorn variables
+    "workers_per_core": workers_per_core,
+    "use_max_workers": use_max_workers,
+    "host": host,
+    "port": port,
+}
+print(json.dumps(log_data))

--- a/docker-support/start-reload.sh
+++ b/docker-support/start-reload.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-80}
+LOG_LEVEL=${LOG_LEVEL:-info}
+
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Uvicorn with live reload
+exec uvicorn --reload --host $HOST --port $PORT --log-level $LOG_LEVEL "$APP_MODULE"

--- a/docker-support/start.sh
+++ b/docker-support/start.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env sh
+set -e
+
+if [ -f /app/app/main.py ]; then
+    DEFAULT_MODULE_NAME=app.main
+elif [ -f /app/main.py ]; then
+    DEFAULT_MODULE_NAME=main
+fi
+MODULE_NAME=${MODULE_NAME:-$DEFAULT_MODULE_NAME}
+VARIABLE_NAME=${VARIABLE_NAME:-app}
+export APP_MODULE=${APP_MODULE:-"$MODULE_NAME:$VARIABLE_NAME"}
+
+if [ -f /app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/gunicorn_conf.py
+elif [ -f /app/app/gunicorn_conf.py ]; then
+    DEFAULT_GUNICORN_CONF=/app/app/gunicorn_conf.py
+else
+    DEFAULT_GUNICORN_CONF=/gunicorn_conf.py
+fi
+export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
+export WORKER_CLASS=${WORKER_CLASS:-"uvicorn.workers.UvicornWorker"}
+
+# If there's a prestart.sh script in the /app directory or other path specified, run it before starting
+PRE_START_PATH=${PRE_START_PATH:-/app/prestart.sh}
+echo "Checking for script in $PRE_START_PATH"
+if [ -f $PRE_START_PATH ] ; then
+    echo "Running script $PRE_START_PATH"
+    . "$PRE_START_PATH"
+else 
+    echo "There is no script $PRE_START_PATH"
+fi
+
+# Start Gunicorn
+exec gunicorn -k "$WORKER_CLASS" -c "$GUNICORN_CONF" "$APP_MODULE"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 click==7.1.2
 joblib==1.0.1
 lemminflect==0.2.2
-nltk==3.5
-numpy==1.19.5
-regex==2021.3.17
+nltk==3.6.2
+numpy==1.20.2
+regex==2021.4.4
 textblob==0.15.3
-tqdm==4.59.0
+tqdm==4.60.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 attrs==20.3.0
 certifi==2020.12.5
 chardet==4.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,21 +1,17 @@
--r requirements.txt
 attrs==20.3.0
 certifi==2020.12.5
 chardet==4.0.0
-dataclasses==0.8
 fastapi==0.63.0
 idna==2.10
-importlib-metadata==3.10.0
 iniconfig==1.1.1
 packaging==20.9
 pluggy==0.13.1
 py==1.10.0
 pydantic==1.8.1
 pyparsing==2.4.7
-pytest==6.2.2
+pytest==6.2.3
 requests==2.25.1
 starlette==0.13.6
 toml==0.10.2
 typing-extensions==3.7.4.3
 urllib3==1.26.4
-zipp==3.4.1


### PR DESCRIPTION
This PR updates dependencies as need for Python 3.9.4, as well as assembles a frankenstein version of the FastAPI container setup modified for Python 3.9. As of this PR, FastAPI only has images for Python 3.8 and below. This takes the Dockerfiles and setup scripts from the repos and assembles them into one based on the Python 3.9 setup. This code will be reverted/removed when 3.9 files are added to the repos. 

See https://github.com/tiangolo/uvicorn-gunicorn-docker and https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker/ and 