### PR TITLE
Remove reference to word tokenization in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 Goal: a simple, lightweight service for:
 - Generating parts of speech tags for a body of text
 - Obtaining the form of a word given a parts of speech tag
-- Obtaining basic tokenization of a given body of text (words, sentences)
+- Obtaining basic tokenization of a given body of text (sentences)
 
-This service doesn't have any logic other than to wrap APIs from TextBlob and Lemminflect. This runs [textblob](https://github.com/sloria/TextBlob) and [lemminflect](https://github.com/bjascob/LemmInflect) as APIs behind FastAPI in a docker container. The supported actions from textblob are `tags`, `words`, and `sentences`, but more may be added. The supported action from lemminflect is `getInflection`. Contributions are welcome. Note this doesn't do anything with certs/ssl/tls/https. Setting up a cluster for ssl termination isn't in scope here.
+This service doesn't have any logic other than to wrap APIs from TextBlob and Lemminflect. This runs [textblob](https://github.com/sloria/TextBlob) and [lemminflect](https://github.com/bjascob/LemmInflect) as APIs behind FastAPI in a docker container. The supported actions from textblob are `tags`, and `sentences`, but more may be added. The supported action from lemminflect is `getInflection`. Contributions are welcome. Note this doesn't do anything with certs/ssl/tls/https. Setting up a cluster for ssl termination isn't in scope here.
 
 ## Container
 Builds on the FastAPI official container image from https://hub.docker.com/r/tiangolo/uvicorn-gunicorn-fastapi/ per the FastAPI [deployment docs](https://fastapi.tiangolo.com/deployment/docker) for Python 3.6.


### PR DESCRIPTION
At this time, only sentencecs is supported

Signed-off-by: Moses Mendoza <mendoza.moses@gmail.com>